### PR TITLE
[ADR] Add ADR template and AI prompts

### DIFF
--- a/ADRs/ADR_AI_NEW_PROMPT.md
+++ b/ADRs/ADR_AI_NEW_PROMPT.md
@@ -1,0 +1,22 @@
+Consider the following documents and conversations:
+```markdown
+<copy/paste documentation from the web, etc.>
+```
+
+team comments:
+```
+<copy/paste comments from notion, discord, GitHub, etc.>
+```
+
+[optional, arbitrary label for context:]
+```
+<copy/paste specific docs, code, etc.>
+```
+
+ADR template
+```markdown
+<copy/paste ADR_TEMPLATE.md>
+```
+
+use the above ADR template to generate the following architecture decision records:
+1. &lt;summary of ADR purpose&gt;

--- a/ADRs/ADR_AI_REFINE_PROMPT.md
+++ b/ADRs/ADR_AI_REFINE_PROMPT.md
@@ -1,0 +1,24 @@
+Consider the following documents and conversations:
+```markdown
+<copy/paste documentation from the web, etc.>
+```
+
+team comments:
+```
+<copy/paste comments from notion, discord, GitHub, etc.>
+```
+
+[optional, arbitrary label for context:]
+```
+<copy/paste specific docs, code, etc.>
+```
+
+ADR template
+```markdown
+<copy/paste ADR_TEMPLATE.md>
+```
+
+update and refine the following ADR document while keeping it consistent with the above ADR template:
+```markdown
+<copy/paste existing ADR document>
+```

--- a/ADRs/ADR_TEMPLATE.md
+++ b/ADRs/ADR_TEMPLATE.md
@@ -1,0 +1,72 @@
+# [short title of solved problem and solution]
+
+* Status: [proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)] <!-- optional -->
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
+
+Technical Story: [description | ticket/issue URL] <!-- optional -->
+
+## Context and Problem Statement
+
+In the context of <use case/user story u>, facing <concern c> we decided for <option o> and neglected <other options>, to achieve <system qualities/desired consequences>, accepting <downside d/undesired consequences>, because <additional rationale>.
+
+## Decision Drivers <!-- optional -->
+
+* [driver 1, e.g., a force, facing concern, …]
+* [driver 2, e.g., a force, facing concern, …]
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* [option 1]
+* [option 2]
+* [option 3]
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+
+### Positive Consequences <!-- optional -->
+
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
+
+### Negative Consequences <!-- optional -->
+
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option 1]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 2]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 3]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+## Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->

--- a/ADRs/README.md
+++ b/ADRs/README.md
@@ -1,0 +1,50 @@
+# Architecture Decision Records (ADRs)
+
+This repository contains a collection of Architecture Decision Records (ADRs) that document important decisions made during the development of our project.
+ADRs help us maintain a historical record of our design choices, making it easier for both current and future team members to understand the rationale behind those decisions.
+
+## What is an Architecture Decision Record?
+
+An Architecture Decision Record (ADR) is a concise document that captures a single decision and its context, including the problem statement, decision drivers, considered options, and the chosen solution.
+ADRs provide a way to communicate and preserve architectural decisions in a structured format, ensuring that the decision-making process remains transparent and easy to follow.
+
+## How are we using ADRs?
+
+We use ADRs to document significant design choices that impact the overall architecture of our system.
+These decisions may include, but are not limited to:
+
+- Selection of technologies or libraries
+- Changes in data models or schemas
+- Design patterns or architectural styles
+- Adoption of new processes or methodologies
+
+We aim to create ADRs as early as possible in the decision-making process, allowing for review and discussion by the entire team.
+ADRs are then committed to this repository, providing a historical record of our architectural decisions.
+
+## Using LLMs for ADR Generation and Refinement
+
+In addition to the conventional (i.e. manual) method, we are also experimenting with using large language models, such as OpenAI's GPT, to generate and refine ADR documents.
+These prompts are included in the ADRs directory which can help automate the process of creating ADRs, while still ensuring that the content is relevant and accurate.
+
+To use the large language models for ADR generation, simply provide the necessary context and problem statement as input to the model, and it will generate a draft ADR based on the given information.
+The generated ADR can then be reviewed and refined by the team members to ensure its accuracy and completeness.
+
+## Contributing
+
+To contribute a new ADR, please follow these steps:
+
+1. Create a new branch for your ADR.
+2. Copy the ADR template from `ADR_TEMPLATE.md` and create a new file with the appropriate number and title (e.g., `ADR0003-adopting-multiaddr.md`).
+3. Fill in the necessary information in the new ADR file, following the template structure.
+4. Use the large language model prompts, if desired, to generate or refine the ADR content.
+5. Submit a pull request to merge your ADR branch into the main branch, including a brief description of the problem and solution.
+6. Request a review from the team members, and address any feedback or suggestions provided.
+7. Once approved, merge the pull request to update the repository with the new ADR.
+
+## Links
+
+- [ADR GitHub org](https://adr.github.io/)
+- [Markdown Any Decision Records](https://adr.github.io/madr/)
+- [ADR Explainer & Examples](https://github.com/joelparkerhenderson/architecture-decision-record)
+- [ADR Manager Web UI](https://github.com/adr/adr-manager) (**[live](https://adr.github.io/adr-manager/#/)**)
+- [Planguage - Specifying Non-Functional Requirements](https://www.iaria.org/conferences2012/filesICCGI12/Tutorial%20Specifying%20Effective%20Non-func.pdf)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The implementation of the protocol is accessible [here](https://github.com/pokt-
 
 ## Sections
 
+- [ADRs](ADRs/README.md)
 - [Utility](utility/README.md)
 - [Consensus](consensus/README.md)
 - [P2P](p2p/README.md)


### PR DESCRIPTION
## Changes
- Adds the `./ADRs`  directory
- Adds some prompts for use with LLMs to facilitate in converting existing written context into an ADR and updating ADRs
- Adds an ADR README that describes what an ADR is and how we use them; incl. links to more info
- Updates the README with link the ADR README
