### PR TITLE
[ADR] 0003 - Adopt Libp2p PeerIDs

### DIFF
--- a/ADRs/0003-adopt-libp2p-peer-ids.md
+++ b/ADRs/0003-adopt-libp2p-peer-ids.md
@@ -8,7 +8,7 @@
 
 - [Summary](#summary-)
 - [Problem Statement](#problem-statement-)
-- [Technical Story](#technical-story-)
+- [Background](#background-)
 - [Decision Drivers](#decision-drivers-)
 - [Considered Options](#considered-options-)
 - [Decision Outcome](#decision-outcome-)
@@ -34,7 +34,7 @@ Identities MUST be provable (e.g. via cryptographic signature).
 - We've recently refactored the P2P module to use libp2p for the transport layer. As a result we're already interoperating with libp2p objects and types.
 - We're simultaneously exploring consolidating and simplifying the concept of node identity throughout the codebase wherever reasonable/feasible.
 
-## Technical Story <!-- optional -->
+## Background
 
 [Consolidate and Refactor Node Identity - #348](https://github.com/pokt-network/pocket/issue/348)
 

--- a/ADRs/0003-adopt-libp2p-peer-ids.md
+++ b/ADRs/0003-adopt-libp2p-peer-ids.md
@@ -1,0 +1,59 @@
+# ADR-0003: Adopt Libp2p PeerIDs
+
+* Status: draft
+* Deciders: Pocket Network team
+* Date: 2023-04-14
+
+Technical Story: [Consolidate and Refactor Node Identity - #348](https://github.com/pokt-network/pocket/issue/348)
+
+## Context and Problem Statement
+
+In the context of simplifying and consolidating node identity, facing the need for a unique and verifiable identifier for nodes in the peer-to-peer network, we decided to adopt Libp2p identity/IDs and neglect alternative identity schemes, to achieve a reliable and secure identification system, accepting the additional dependency and integration work, because Libp2p provides a proven solution with robust security features.
+
+## Decision Drivers
+
+* Unique and verifiable node identifiers
+* Secure and reliable identification system
+* Proven solution in the peer-to-peer ecosystem
+
+## Considered Options
+
+* Adopting Libp2p identity/IDs
+* Custom identity scheme
+
+## Decision Outcome
+
+Chosen option: "Adopting Libp2p identity/IDs", because it provides a unique, verifiable, and secure identification system that is proven in the peer-to-peer ecosystem.
+
+### Positive Consequences
+
+* Unique and verifiable node identifiers
+* Secure and reliable identification system
+* Simplified integration with other Libp2p components
+
+### Negative Consequences
+
+* Additional dependency on the Libp2p library
+* Integration work required to adopt Libp2p identity/IDs
+
+## Pros and Cons of the Options
+
+### Adopting Libp2p identity/IDs
+
+* Good, because it provides unique and verifiable node identifiers
+* Good, because it offers a secure and reliable identification system
+* Good, because it is a proven solution in the peer-to-peer ecosystem
+* Bad, because it introduces an additional dependency
+* Bad, because it requires integration work to adopt Libp2p identity/IDs
+
+### Custom identity scheme
+
+* Good, because it doesn't require an additional dependency
+* Bad, because it may lead to a less secure and reliable solution
+* Bad, because it requires development and maintenance efforts
+* Bad, because it may not be compatible with other Libp2p components
+
+### Links
+
+* [`go-libp2p` - `peer.ID`](https://pkg.go.dev/github.com/libp2p/go-libp2p@v0.27.1/core/peer#ID)
+* [pokt-network/pocket#434](https://github.com/pokt-network/pocket/issue/434)

--- a/ADRs/0003-adopt-libp2p-peer-ids.md
+++ b/ADRs/0003-adopt-libp2p-peer-ids.md
@@ -1,6 +1,6 @@
 # ADR-0003: Adopt Libp2p PeerIDs
 
-* Status: draft
+* Status: in review
 * Deciders: Pocket Network team
 * Date: 2023-04-14
 

--- a/ADRs/0003-adopt-libp2p-peer-ids.md
+++ b/ADRs/0003-adopt-libp2p-peer-ids.md
@@ -63,7 +63,6 @@ Chosen option: "Adopting Libp2p identity/IDs", because it provides a unique, ver
 
 - Additional dependency on the Libp2p library
 - Integration work required to adopt Libp2p identity/IDs
-- May not be compatible with other Libp2p components or the refactored P2P module
 
 ## Pros and Cons of the Options <!-- required -->
 
@@ -91,7 +90,7 @@ Cons:
 
 - May lead to a less secure and reliable solution
 - Requires development and maintenance efforts
-- May not be compatible with other Libp2p components
+- May not be compatible with other Libp2p components or the refactored P2P module
 
 ## References <!-- optional -->
 

--- a/ADRs/0003-adopt-libp2p-peer-ids.md
+++ b/ADRs/0003-adopt-libp2p-peer-ids.md
@@ -19,17 +19,17 @@
     - [Custom identity scheme](#custom-identity-scheme)
 - [References](#references-)
 
-## Summary <!-- required -->
+## Summary 
 
 Facing the need for a unique and verifiable identifier for nodes in the peer-to-peer network, we decided to adopt Libp2p identity/IDs and neglect alternative identity schemes, to achieve a reliable and secure identification system, accepting the additional dependency and integration work, because Libp2p provides a proven solution with robust security features.
 
-## Problem Statement <!-- required -->
+## Problem Statement 
 
 At the time of writing, there is no formal specification for identity with respect to pocket network nodes/participants.
 Each node MUST be uniquely identifiable/addressable so that it may be correctly routed to.
 Identities MUST be provable (e.g. via cryptographic signature).
 
-### Context <!-- optional -->
+### Context 
 
 - We've recently refactored the P2P module to use libp2p for the transport layer. As a result we're already interoperating with libp2p objects and types.
 - We're simultaneously exploring consolidating and simplifying the concept of node identity throughout the codebase wherever reasonable/feasible.
@@ -38,33 +38,33 @@ Identities MUST be provable (e.g. via cryptographic signature).
 
 [Consolidate and Refactor Node Identity - #348](https://github.com/pokt-network/pocket/issue/348)
 
-## Decision Drivers <!-- optional -->
+## Decision Drivers 
 
 - Unique and verifiable node identifiers
 - Secure and reliable identification system
 - Proven solution in the peer-to-peer ecosystem
 
-## Considered Options <!-- required -->
+## Considered Options 
 
 1. Adopting Libp2p identity/IDs
 2. Custom identity scheme
 
-## Decision Outcome <!-- required -->
+## Decision Outcome 
 
 Chosen option: "Adopting Libp2p identity/IDs", because it provides a unique, verifiable, and secure identification system that is proven in the peer-to-peer ecosystem.
 
-### Positive Consequences <!-- optional -->
+### Positive Consequences 
 
 - Unique and verifiable node identifiers
 - Secure and reliable identification system
 - Simplified integration with other Libp2p components
 
-### Negative Consequences <!-- optional -->
+### Negative Consequences 
 
 - Additional dependency on the Libp2p library
 - Integration work required to adopt Libp2p identity/IDs
 
-## Pros and Cons of the Options <!-- required -->
+## Pros and Cons of the Options 
 
 ### Adopting Libp2p identity/IDs
 
@@ -92,7 +92,7 @@ Cons:
 - Requires development and maintenance efforts
 - May not be compatible with other Libp2p components or the refactored P2P module
 
-## References <!-- optional -->
+## References 
 
 - [`go-libp2p` - `peer.ID`](https://pkg.go.dev/github.com/libp2p/go-libp2p@v0.27.1/core/peer#ID)
 - [pokt-network/pocket#434](https://github.com/pokt-network/pocket/issue/434)

--- a/ADRs/0003-adopt-libp2p-peer-ids.md
+++ b/ADRs/0003-adopt-libp2p-peer-ids.md
@@ -6,6 +6,7 @@
 
 **Table of Contents**
 
+- [Summary](#summary-)
 - [Problem Statement](#problem-statement-)
 - [Technical Story](#technical-story-)
 - [Decision Drivers](#decision-drivers-)
@@ -18,9 +19,20 @@
     - [Custom identity scheme](#custom-identity-scheme)
 - [References](#references-)
 
+## Summary <!-- required -->
+
+Facing the need for a unique and verifiable identifier for nodes in the peer-to-peer network, we decided to adopt Libp2p identity/IDs and neglect alternative identity schemes, to achieve a reliable and secure identification system, accepting the additional dependency and integration work, because Libp2p provides a proven solution with robust security features.
+
 ## Problem Statement <!-- required -->
 
-In the context of simplifying and consolidating node identity, facing the need for a unique and verifiable identifier for nodes in the peer-to-peer network, we decided to adopt Libp2p identity/IDs and neglect alternative identity schemes, to achieve a reliable and secure identification system, accepting the additional dependency and integration work, because Libp2p provides a proven solution with robust security features.
+At the time of writing, there is no formal specification for identity with respect to pocket network nodes/participants.
+Each node MUST be uniquely identifiable/addressable so that it may be correctly routed to.
+Identities MUST be provable (e.g. via cryptographic signature).
+
+### Context <!-- optional -->
+
+- We've recently refactored the P2P module to use libp2p for the transport layer. As a result we're already interoperating with libp2p objects and types.
+- We're simultaneously exploring consolidating and simplifying the concept of node identity throughout the codebase wherever reasonable/feasible.
 
 ## Technical Story <!-- optional -->
 
@@ -51,6 +63,7 @@ Chosen option: "Adopting Libp2p identity/IDs", because it provides a unique, ver
 
 - Additional dependency on the Libp2p library
 - Integration work required to adopt Libp2p identity/IDs
+- May not be compatible with other Libp2p components or the refactored P2P module
 
 ## Pros and Cons of the Options <!-- required -->
 
@@ -61,6 +74,7 @@ Pros:
 - Provides unique and verifiable node identifiers
 - Offers a secure and reliable identification system
 - Proven solution in the peer-to-peer ecosystem
+- Aligns with the refactored P2P module, which already uses libp2p for the transport layer
 
 Cons:
 

--- a/ADRs/0003-adopt-libp2p-peer-ids.md
+++ b/ADRs/0003-adopt-libp2p-peer-ids.md
@@ -1,59 +1,85 @@
-# ADR-0003: Adopt Libp2p PeerIDs
+# Adopting Libp2p PeerIDs <!-- omit in toc -->
 
-* Status: in review
-* Deciders: Pocket Network team
-* Date: 2023-04-14
+- Status: in review
+- Deciders: Pocket Network team
+- Date: 2023-04-14
 
-Technical Story: [Consolidate and Refactor Node Identity - #348](https://github.com/pokt-network/pocket/issue/348)
+**Table of Contents**
 
-## Context and Problem Statement
+- [Problem Statement](#problem-statement-)
+- [Technical Story](#technical-story-)
+- [Decision Drivers](#decision-drivers-)
+- [Considered Options](#considered-options-)
+- [Decision Outcome](#decision-outcome-)
+    - [Positive Consequences](#positive-consequences-)
+    - [Negative Consequences](#negative-consequences-)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options-)
+    - [Adopting Libp2p identity/IDs](#adopting-libp2p-identityids)
+    - [Custom identity scheme](#custom-identity-scheme)
+- [References](#references-)
+
+## Problem Statement <!-- required -->
 
 In the context of simplifying and consolidating node identity, facing the need for a unique and verifiable identifier for nodes in the peer-to-peer network, we decided to adopt Libp2p identity/IDs and neglect alternative identity schemes, to achieve a reliable and secure identification system, accepting the additional dependency and integration work, because Libp2p provides a proven solution with robust security features.
 
-## Decision Drivers
+## Technical Story <!-- optional -->
 
-* Unique and verifiable node identifiers
-* Secure and reliable identification system
-* Proven solution in the peer-to-peer ecosystem
+[Consolidate and Refactor Node Identity - #348](https://github.com/pokt-network/pocket/issue/348)
 
-## Considered Options
+## Decision Drivers <!-- optional -->
 
-* Adopting Libp2p identity/IDs
-* Custom identity scheme
+- Unique and verifiable node identifiers
+- Secure and reliable identification system
+- Proven solution in the peer-to-peer ecosystem
 
-## Decision Outcome
+## Considered Options <!-- required -->
+
+1. Adopting Libp2p identity/IDs
+2. Custom identity scheme
+
+## Decision Outcome <!-- required -->
 
 Chosen option: "Adopting Libp2p identity/IDs", because it provides a unique, verifiable, and secure identification system that is proven in the peer-to-peer ecosystem.
 
-### Positive Consequences
+### Positive Consequences <!-- optional -->
 
-* Unique and verifiable node identifiers
-* Secure and reliable identification system
-* Simplified integration with other Libp2p components
+- Unique and verifiable node identifiers
+- Secure and reliable identification system
+- Simplified integration with other Libp2p components
 
-### Negative Consequences
+### Negative Consequences <!-- optional -->
 
-* Additional dependency on the Libp2p library
-* Integration work required to adopt Libp2p identity/IDs
+- Additional dependency on the Libp2p library
+- Integration work required to adopt Libp2p identity/IDs
 
-## Pros and Cons of the Options
+## Pros and Cons of the Options <!-- required -->
 
 ### Adopting Libp2p identity/IDs
 
-* Good, because it provides unique and verifiable node identifiers
-* Good, because it offers a secure and reliable identification system
-* Good, because it is a proven solution in the peer-to-peer ecosystem
-* Bad, because it introduces an additional dependency
-* Bad, because it requires integration work to adopt Libp2p identity/IDs
+Pros:
+
+- Provides unique and verifiable node identifiers
+- Offers a secure and reliable identification system
+- Proven solution in the peer-to-peer ecosystem
+
+Cons:
+
+- Introduces an additional dependency
+- Requires integration work to adopt Libp2p identity/IDs
 
 ### Custom identity scheme
 
-* Good, because it doesn't require an additional dependency
-* Bad, because it may lead to a less secure and reliable solution
-* Bad, because it requires development and maintenance efforts
-* Bad, because it may not be compatible with other Libp2p components
+Pros:
 
-### Links
+- Doesn't require an additional dependency
 
-* [`go-libp2p` - `peer.ID`](https://pkg.go.dev/github.com/libp2p/go-libp2p@v0.27.1/core/peer#ID)
-* [pokt-network/pocket#434](https://github.com/pokt-network/pocket/issue/434)
+Cons:
+
+- May lead to a less secure and reliable solution
+- Requires development and maintenance efforts
+- May not be compatible with other Libp2p components
+
+## References <!-- optional -->
+
+- [`go-libp2p` - `peer.ID`](https://pkg.go.dev/github.com/libp2p/go-libp2p@v0.27.1/core/peer#ID)
+- [pokt-network/pocket#434](https://github.com/pokt-network/pocket/issue/434)


### PR DESCRIPTION
## Summary

This pull request adds an Architecture Decision Record (ADR) for adopting Libp2p identity/IDs to simplify and consolidate node identity in our system. The ADR explains the context, problem statement, decision drivers, considered options, and the decision outcome, along with the positive and negative consequences of the chosen option.

The chosen option is to adopt Libp2p identity/IDs, as it provides a unique, verifiable, and secure identification system that is proven in the peer-to-peer ecosystem.

Please review the ADR and provide feedback on:

- The clarity of the problem statement and context
- The thoroughness of the decision drivers and considered options
- The appropriateness of the chosen option given the decision drivers
- Any additional considerations that may have been overlooked
- Any changes in formatting, grammar, or language for better readability

## Related Issues

- pokt-network/pocket#348
- pokt-network/pocket#434
