### PR TITLE
[ADRs] Update ADR docs & template

### DIFF
--- a/ADRs/ADR_TEMPLATE.md
+++ b/ADRs/ADR_TEMPLATE.md
@@ -1,10 +1,10 @@
 # [short title of solved problem and solution]
 
-* Status: [proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)] <!-- optional -->
+* Status: [draft | in review | changes needed | withdrawn | accepted | superseded by [ADR-XXXX](0002-example.md)] <!-- optional -->
 * Deciders: [list everyone involved in the decision] <!-- optional -->
 * Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
 
-Technical Story: [description | ticket/issue URL] <!-- optional -->
+Technical Story: [description | issue/discussion URL] <!-- optional -->
 
 ## Context and Problem Statement
 

--- a/ADRs/README.md
+++ b/ADRs/README.md
@@ -68,7 +68,7 @@ stateDiagram
 To contribute a new ADR, please follow these steps:
 
 1. Create a new branch for your ADR.
-2. Copy the ADR template from `ADR_TEMPLATE.md` and create a new file with the appropriate number and title (e.g., `ADR0003-adopting-multiaddr.md`).
+2. Copy the ADR template from `ADR_TEMPLATE.md` and create a new file with the next ADR number and title as an [imperative mood verb phrase](https://en.wikipedia.org/wiki/Imperative_mood) (e.g., `0003-adopt-multiaddr.md`).
 3. Fill in the necessary information in the new ADR file, following the template structure.
 4. Use the large language model prompts, if desired, to generate or refine the ADR content.
 5. Submit a pull request to merge your ADR branch into the main branch, including a brief description of the problem and solution.

--- a/ADRs/README.md
+++ b/ADRs/README.md
@@ -29,6 +29,40 @@ These prompts are included in the ADRs directory which can help automate the pro
 To use the large language models for ADR generation, simply provide the necessary context and problem statement as input to the model, and it will generate a draft ADR based on the given information.
 The generated ADR can then be reviewed and refined by the team members to ensure its accuracy and completeness.
 
+## Workflow
+
+```mermaid
+timeline
+    Previous Sprint(s): Existing ADR(s)
+    Creation: Research and/or design issue started
+            : ADR tracks the decision making separate from other outputs
+            : Other outputs (e.g. docs, code) may cite and/or implement an ADR
+    Observation: As the team surfaces additional, relevant information   (e.g. conversations in discord, GitHub, etc.) over time, ADRs are appended to (format currently unspecified)
+                : Examples include things one might use  `//CONSIDERATION`, `//IMPROVE`, or `//DISCUSS` for in code
+    Cleanup/consolidate (optional): consolidate accumulated additional information by regenerating a new ADR which obsoletes the current
+    Obsoletion: When an ADR conflicts with (a) prior one(s), the prior ADR's status MUST be set to "obsolete" with a reference to the newer ADR
+            : If there are aspects of the prior ADR which the conflicting ADR does not address they MUST be consolidated (regenerated) into an additional (new) ADR which also obsoletes the prior ADR(s). This should all surface during review, if not sooner
+```
+
+## Document status flowchart
+
+```mermaid
+stateDiagram
+    state "In Review" as review
+    state "Changes Needed" as change
+    
+    [*] --> Draft : Author opens a PR
+    Draft --> review : PR is marked 'Ready for Review'
+    review --> change : Reviewer requests changes
+    change --> review : Reviewer approves changes
+    change --> Withdrawn : PR is closed
+    review --> Accepted : PR is merged
+    Accepted --> Superseded : Superseding ADR becomes 'Accepted
+
+    Draft --> Withdrawn : PR is closed
+    review --> Withdrawn: PR is closed
+```
+
 ## Contributing
 
 To contribute a new ADR, please follow these steps:


### PR DESCRIPTION
This PR updates the ADR_TEMPLATE.md and README.md files, modifying the status options in the template and adding a workflow and document status flowchart to the README file.

### Changes

1. Updated `Status` field placeholders in ADR_TEMPLATE.md with new options to match the statuses flowchart.
2. Changed `Technical Story` field placeholder in ADR_TEMPLATE.md to be "issue/discussion URL".
3. Added a `Workflow` section with a mermaid timeline to README.md.
4. Included a `Document status flowchart` section with a mermaid state diagram in README.md.
5. Reword `Contributing` step 2 a bit for clarity.
